### PR TITLE
Add release tag to Docker build and modify Github Actions workflow

### DIFF
--- a/.github/workflows/docker_landseg.yml
+++ b/.github/workflows/docker_landseg.yml
@@ -3,32 +3,36 @@ name: Docker Build and Push
 on:
   push:
     branches: [ "development" ]
-#    release:
-#      types:
-#        - released
-#
+#  release:
+#    types:
+#      - released
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     environment: stable_docker
     permissions:
-        id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
-      - name: Checkout code #clones repository
-        uses: actions/checkout@v3 #the action that is used to checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-      - name: Login to DockerHub 
-        uses: docker/login-action@v1 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
+      - name: Set release tag
+        id: vars
+        run: echo "::set-output name=tag::${{ github.event.release.tag_name || 'latest' }}"
+
       - name: Build and Push Docker image
-        uses: docker/build-push-action@v2 #the action that is used to build and push any image
+        uses: docker/build-push-action@v2
         with:
-            context: ./image_files/land-seg/
-            file: ./image_files/land-seg/Dockerfile
-            push: true
-            tags: |
-                guorbit/orbit-software-landseg:latest
-                guorbit/orbit-software-landseg:${{github.event.release.tag_name}}
+          context: ./image_files/land-seg/
+          file: ./image_files/land-seg/Dockerfile
+          push: true
+          tags: |
+            guorbit/orbit-software-landseg:latest
+            guorbit/orbit-software-landseg:${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
Uncommented the release type section in the Github Actions workflow, enabling the building and pushing of Docker images upon release, in addition to current push triggers on the development branch.

Also, added a step in the workflow to set the release tag, aiding in version control and traceability of Docker images. Changes aim to automate and better manage the Docker image creation process during development and release stages, ensuring up-to-date and identifiable images.