### PR TITLE
Update pip install command in Dockerfile

### DIFF
--- a/image_files/land-seg/Dockerfile
+++ b/image_files/land-seg/Dockerfile
@@ -33,7 +33,7 @@ RUN pip install --upgrade setuptools
 
 
 RUN $PIP_INSTALL install git+https://github.com/guorbit/utilities.git@dev_dataloader_filetype_ext
-RUN pip install \
+RUN $PIP_INSTALL \
     cython\
     torch==2.0 \
     torcheval==0.0.7\


### PR DESCRIPTION
Replaced the direct "pip install" command with the variable "$PIP_INSTALL" in Dockerfile. This provides flexibility in changing pip install command structure uniformly across the script without manually replacing each instance. This change enhances maintainability and robustness of Dockerfile script.