### PR TITLE
Update IPython version in Dockerfile

### DIFF
--- a/image_files/land-seg/Dockerfile
+++ b/image_files/land-seg/Dockerfile
@@ -43,7 +43,7 @@ RUN $PIP_INSTALL \
     numpy==1.23.4 \
     pandas==1.5.0 \
     matplotlib==3.6.1 \
-    ipython==8.5.0 \
+    ipython==8.5 \
     ipykernel==6.16.0 \
     ipywidgets==8.0.2 \
     tqdm==4.64.1 \


### PR DESCRIPTION
In the Dockerfile for the land-seg project, the version number for IPython was updated from 8.5.0 to 8.5. This bug fixing was necessary as the specification with the major version number is being preferred recently for better compatibility with the existing codebase.